### PR TITLE
Added a feature for waiting expected result while API request is processed

### DIFF
--- a/src/main/java/client/BaseClient.java
+++ b/src/main/java/client/BaseClient.java
@@ -1,5 +1,6 @@
 package client;
 
+import enums.ERequestType;
 import io.qameta.allure.Step;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.builder.ResponseSpecBuilder;
@@ -8,6 +9,7 @@ import io.restassured.specification.RequestSpecification;
 import io.restassured.specification.ResponseSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.Formatter;
 
 public class BaseClient {
     final private static String BASE_URI = "https://petstore.swagger.io";
@@ -43,5 +45,20 @@ public class BaseClient {
         LOGGER.debug("building response specification ");
         return new ResponseSpecBuilder()
             .build();
+    }
+
+    protected static RequestExecutor requestType(ERequestType requestType) {
+        switch (requestType) {
+            case DELETE:
+                return (request, endpoint, endpointExtra) -> request.delete(String.valueOf(new Formatter().format(endpoint, endpointExtra)));
+            case GET:
+                return (request, endpoint, endpointExtra) -> request.get(String.valueOf(new Formatter().format(endpoint, endpointExtra)));
+            case PUT:
+                return (request, endpoint, endpointExtra) -> request.put(String.valueOf(new Formatter().format(endpoint, endpointExtra)));
+            case POST:
+                return (request, endpoint, endpointExtra) -> request.post(String.valueOf(new Formatter().format(endpoint, endpointExtra)));
+            default:
+                return null;
+        }
     }
 }

--- a/src/main/java/client/RequestExecutor.java
+++ b/src/main/java/client/RequestExecutor.java
@@ -1,0 +1,8 @@
+package client;
+
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+
+interface RequestExecutor {
+    Response executeRequest(RequestSpecification reqSpec, String endpoint, String endpointExtra);
+}

--- a/src/main/java/client/StoreClient.java
+++ b/src/main/java/client/StoreClient.java
@@ -1,116 +1,149 @@
 package client;
 
+import data.ReusableMethods;
 import dto.requests.ResponseInfo;
 import dto.requests.store.Order;
+import enums.ERequestType;
 import io.qameta.allure.Step;
 import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.apache.http.HttpStatus;
 
 import java.util.Formatter;
+import java.util.Objects;
 
 public class StoreClient extends BaseClient {
     final private static String STORE_ORDER_ENDPOINT = "/v2/store/order";
     final private static String STORE_ORDER_BY_ID_ENDPOINT = STORE_ORDER_ENDPOINT + "/%s";
+    final private static int THIRTY_SECONDS = 60;
 
     @Step("Sending POST request to /store/order")
     public static Order postOrder(Order orderToPost) {
         LOGGER.debug("sending request");
-        RequestSpecification res = RestAssured.given()
-            .spec(buildReq())
-            .body(orderToPost);
+        RequestSpecification reqSpec = RestAssured.given()
+                .spec(buildReq())
+                .body(orderToPost);
+
+        LOGGER.debug("checking response");
+        Response response = verifyResponse(reqSpec, ERequestType.POST, STORE_ORDER_ENDPOINT, 0);
 
         LOGGER.debug("expecting response");
-        return res
-            .when()
-            .post(STORE_ORDER_ENDPOINT)
-            .then()
-            .statusCode(HttpStatus.SC_OK)
-            .spec(buildRes())
-            .log()
-            .body()
-            .extract()
-            .response()
-            .as(Order.class);
+        return response
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .spec(buildRes())
+                .log()
+                .body()
+                .extract()
+                .response()
+                .as(Order.class);
     }
 
     @Step("Sending GET request to /store/order by ID {0}")
     public static Order getOrderById(long orderId) {
         LOGGER.debug("sending request");
-        RequestSpecification res = RestAssured.given()
-            .spec(buildReq());
+        RequestSpecification reqSpec = RestAssured.given()
+                .spec(buildReq());
+
+        LOGGER.debug("checking response");
+        Response response = verifyResponse(reqSpec, ERequestType.GET, STORE_ORDER_BY_ID_ENDPOINT, orderId);
 
         LOGGER.debug("expecting response");
-        return res
-            .when()
-            .get(String.valueOf(new Formatter().format(STORE_ORDER_BY_ID_ENDPOINT, orderId)))
-            .then()
-            .statusCode(HttpStatus.SC_OK)
-            .spec(buildRes())
-            .log()
-            .body()
-            .extract()
-            .response()
-            .as(Order.class);
+        return response
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .spec(buildRes())
+                .log()
+                .body()
+                .extract()
+                .response()
+                .as(Order.class);
     }
 
     @Step("Sending DELETE request to /store/order by ID {0}")
     public static ResponseInfo deleteOrderById(long orderId) {
         LOGGER.debug("sending request");
-        RequestSpecification res = RestAssured.given()
-            .spec(buildReq());
+        RequestSpecification reqSpec = RestAssured.given()
+                .spec(buildReq())
+                .when();
 
-        LOGGER.debug("expecting response");
-        return res
-            .when()
-            .delete(String.valueOf(new Formatter().format(STORE_ORDER_BY_ID_ENDPOINT, orderId)))
-            .then()
-            .statusCode(HttpStatus.SC_OK)
-            .spec(buildUncheckedRes())
-            .log()
-            .body()
-            .extract()
-            .response()
-            .as(ResponseInfo.class);
+        LOGGER.debug("checking response");
+        Response response = verifyResponse(reqSpec, ERequestType.DELETE, STORE_ORDER_BY_ID_ENDPOINT, orderId);
+
+        LOGGER.debug("extracting response");
+        return response
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .spec(buildUncheckedRes())
+                .log()
+                .body()
+                .extract()
+                .response()
+                .as(ResponseInfo.class);
     }
 
     @Step("Sending GET request for non existent order to /store/order by ID {0}")
     public static ResponseInfo getNonexistentOrderById(long orderId) {
         LOGGER.debug("sending request");
         RequestSpecification res = RestAssured.given()
-            .spec(buildReq());
+                .spec(buildReq());
 
         LOGGER.debug("expecting response");
         return res
-            .when()
-            .get(String.valueOf(new Formatter().format(STORE_ORDER_BY_ID_ENDPOINT, orderId)))
-            .then()
-            .statusCode(HttpStatus.SC_NOT_FOUND)
-            .spec(buildRes())
-            .log()
-            .body()
-            .extract()
-            .response()
-            .as(ResponseInfo.class);
+                .when()
+                .get(String.valueOf(new Formatter().format(STORE_ORDER_BY_ID_ENDPOINT, orderId)))
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .spec(buildRes())
+                .log()
+                .body()
+                .extract()
+                .response()
+                .as(ResponseInfo.class);
     }
 
     @Step("Sending DELETE request for non existent order to /store/order by ID {0}")
     public static ResponseInfo deleteNonExistingOrderById(long orderId) {
         LOGGER.debug("sending request");
         RequestSpecification res = RestAssured.given()
-            .spec(buildReq());
+                .spec(buildReq());
 
         LOGGER.debug("expecting response");
         return res
-            .when()
-            .delete(String.valueOf(new Formatter().format(STORE_ORDER_BY_ID_ENDPOINT, orderId)))
-            .then()
-            .statusCode(HttpStatus.SC_NOT_FOUND)
-            .spec(buildUncheckedRes())
-            .log()
-            .body()
-            .extract()
-            .response()
-            .as(ResponseInfo.class);
+                .when()
+                .delete(String.valueOf(new Formatter().format(STORE_ORDER_BY_ID_ENDPOINT, orderId)))
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .spec(buildUncheckedRes())
+                .log()
+                .body()
+                .extract()
+                .response()
+                .as(ResponseInfo.class);
+    }
+
+    private static Response verifyResponse(RequestSpecification reqSpec, ERequestType requestType, String endpoint, long orderId) {
+        int actualStatusCode;
+        int i = 0;
+        String orderIdStr;
+
+        if (orderId == 0) {
+            orderIdStr = null;
+        } else {
+            orderIdStr = String.valueOf(orderId);
+        }
+
+        Response response = null;
+        do {
+            if (i == THIRTY_SECONDS) {
+                break;
+            }
+            response = Objects.requireNonNull(requestType(requestType)).executeRequest(reqSpec, endpoint, orderIdStr);
+            actualStatusCode = response.getStatusCode();
+            ReusableMethods.waiter();
+            i++;
+        } while (HttpStatus.SC_OK != actualStatusCode);
+        return response;
     }
 }

--- a/src/main/java/data/ReusableMethods.java
+++ b/src/main/java/data/ReusableMethods.java
@@ -2,7 +2,6 @@ package data;
 
 import dto.requests.user.User;
 import org.testng.Assert;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
@@ -31,5 +30,13 @@ public class ReusableMethods {
         Assert.assertEquals(newUser.getEmail(), expectedUser.getEmail());
         Assert.assertEquals(newUser.getPassword(), expectedUser.getPassword());
         Assert.assertEquals(newUser.getPhone(), expectedUser.getPhone());
+    }
+
+    public static void waiter() {
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/enums/ERequestType.java
+++ b/src/main/java/enums/ERequestType.java
@@ -1,0 +1,14 @@
+package enums;
+
+public enum ERequestType {
+    GET("get"),
+    DELETE("delete"),
+    POST("post"),
+    PUT("put");
+
+    private final String requestType;
+
+    ERequestType(String requestType) {this.requestType = requestType;}
+
+    public String getRequestType() {return requestType;}
+}


### PR DESCRIPTION
- Added ERequestType.java an Enum class in order to specify type of http request;
- Added RequestExecutor.java for creating interface for executing requests with income data such as request specification, endpoint, extra endpoint;
- Added a method 'requestType' to BaseClient.java, in order to choose what type of request should be executed;
- Added a method 'verifyResponse' to StoreClient.java, which contains the logic of checking server for expected response, by sending requests with short period of time. Also added checking response step in some creating requests methods;
- Added a method 'waiter' to ReusableMethods.java, a basic timer for doing waits.